### PR TITLE
Fixed the its file name bug

### DIFF
--- a/create_subjects/seg_original.py
+++ b/create_subjects/seg_original.py
@@ -122,7 +122,8 @@ def create_wav_chunks(output_dir, timestamps, full_audio, audio_file, corpus, ag
         if len(its_files)>1:
             print("More than one its file! Panic",its_files)
             sys.quit()
-        its_name=str(its_files)[-29:len(str(its_files))-6]
+        #its_name=str(its_files)[-29:len(str(its_files))-6]
+        its_name = os.path.basename(its_files[0])
         difference = float(offset)-float(onset)
         if difference < 1.0:
             tgt=1.0-difference


### PR DESCRIPTION
I am not sure what the format of `its_files` is expected to be, but currently, if `its_files` is `['/home/sarp/Documents/source-data/1234.its']`, then `its_name` gets set to `'ents/source-data/1234.its'`. This fixes that. 